### PR TITLE
Update version `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitidy",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gitidy",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "probot": "^12.2.4"


### PR DESCRIPTION
• Update `package-lock.json` caused by a missed update on prev release
